### PR TITLE
[ADD] ssh key text as env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,10 +190,18 @@ the `known_hosts` file is provided.  This can help avoid issues for hosts with
 dynamic IP addresses, but removes some additional protection against DNS
 spoofing attacks.  Host IP Checking is enabled by default.
 
+#### SSH_KEY
+
+You can specify the SSH key using Environnement variable.
+
+If both SSH_KEY and  SSH_KEY_FILE are passed, SSH_KEY_FILE is used and SSH_KEY is ignored.
+
 #### SSH_KEY_FILE
 
 In the event you wish to store the key in Docker Secrets, you may wish to
 set this to `/run/secrets/*secret-name*`
+
+If both SSH_KEY and  SSH_KEY_FILE are passed, SSH_KEY_FILE is used and SSH_KEY is ignored.
 
 #### SSH_KNOWN_HOSTS_FILE
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -89,6 +89,32 @@ services:
     volumes:
       - sshkeys:/opt/
 
+  local-with-env:
+    build: .
+    hostname: local
+    depends_on:
+      - bootloader
+      - remote
+      - target
+    environment:
+      - TERM=xterm
+      - SSH_BIND_IP=203.0.113.10
+      - SSH_REMOTE_USER=root
+      - SSH_REMOTE_HOST=203.0.113.10
+      - SSH_REMOTE_PORT=22
+      - SSH_TARGET_HOST=203.0.113.100
+      - SSH_TARGET_PORT=22
+      - SSH_TUNNEL_PORT=11112
+      - SSH_KNOWN_HOSTS_FILE=/dev/null
+      - SSH_STRICT_HOST_IP_CHECK=false
+    networks:
+      testnet:
+        ipv4_address: 203.0.113.112
+    restart: always
+    volumes:
+      - sshkeys:/opt/
+    entrypoint:  ["sh", "-c",  "SSH_KEY=`cat /opt/id_rsa` /entrypoint.sh"]
+
   sut:
     build:
       context: ./test
@@ -96,14 +122,20 @@ services:
     hostname: source
     depends_on:
       - local
+      - local-with-env
     command: /bin/sh -c "(
               while [ ! -f /opt/id_rsa ]; do echo 'waiting for ssh-keygen...'; sleep 2; done;
               while [ ! -f /opt/authorized_keys ]; do echo 'waiting for authorized_keys...'; sleep 2; done;
               while [ ! -f /opt/remote.txt ]; do echo 'waiting for remote...'; sleep 2; done;
               while [ ! -f /opt/target.txt ]; do echo 'waiting for target...'; sleep 2; done;
-              echo 'testing...'
-              ssh -o StrictHostKeyChecking=no -i /opt/id_rsa root@203.0.113.10 -p 11111 -C 'if [ `hostname` == "target" ]; then echo '[INFO ] success'; exit 0; else echo '[PANIC] hostname is not target'; exit 1; fi';
-             )"
+              echo 'testing with key file';
+              ssh -o StrictHostKeyChecking=no -i /opt/id_rsa root@203.0.113.10 -p 11111 -C 'if [ `hostname` == 'target' ]; then echo '[INFO ] success'; exit 0; else echo '[PANIC] hostname is not target'  `hostname`; exit 1; fi';
+              STATUS1=$$?;
+              echo 'testing with environment variable';
+              ssh -o StrictHostKeyChecking=no -i /opt/id_rsa root@203.0.113.10 -p 11112 -C 'if [ `hostname` == 'target' ]; then echo '[INFO ] success'; exit 0; else echo '[PANIC] using env var, hostname is not target' `hostname`; exit 1; fi';
+              STATUS2=$$?;
+              if [ $${STATUS1} = '0' -a $${STATUS2} = '0' ]; then exit 0 ; else exit 1 ; fi
+              )"
     networks:
       testnet:
         ipv4_address: 203.0.113.200

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -35,6 +35,10 @@ Just a reminder, here is a text-based overview of a complete end-to-end setup.
 > The SOURCE (203.0.113.200) connects to the REMOTE (203.0.113.10) device
 > TUNNEL_PORT (:11111) to get to the TARGET (203.0.113.100) TARGET_PORT (:22).
 
+There is a similar setup for local-with-env which is living on 203.0.113.112
+and setting up a tunnel on REMOTE (203.0.113.10) on port :11112. This setup
+just passing the SSH key using an environment variable instead of a file.
+
 ### 203.0.113.0/24
 
 Do not be alarmed, the address space `203.0.113.0/24` is not actually on the
@@ -203,6 +207,10 @@ branding variables.  This is as close to production as we can get.
 Since this container never exists, and we need Docker Hub to test the exit code,
 we must use another container (`sut`) to actually perform testing. This service
 gets setup as if it was in production with one minor difference.
+
+### local-with-env
+
+Same as local, but we pass the ssh key as an environment variable.
 
 #### SSH_KNOWN_HOSTS_FILE and SSH_STRICT_HOST_IP_CHECK
 

--- a/rootfs/entrypoint.sh
+++ b/rootfs/entrypoint.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/dumb-init /bin/sh
 source version.sh
-
-# Set up key file
-KEY_FILE=${SSH_KEY_FILE:=/id_rsa}
-if [ ! -f "${KEY_FILE}" ]; then
-    echo "[FATAL] No SSH Key file found"
-    exit 1
-fi
 eval $(ssh-agent -s)
-cat "${SSH_KEY_FILE}" | ssh-add -k -
+if [ -n "${SSH_KEY_FILE}" ]; then
+    # Set up key file
+    if [ ! -f "${SSH_KEY_FILE}" ]; then
+        echo "[FATAL] No SSH Key file found"
+        exit 1
+    fi
+    cat "${SSH_KEY_FILE}" | ssh-add -k -
+else
+    if [ -n "${SSH_KEY}" ]; then
+        echo "${SSH_KEY}" | ssh-add -k -
+    fi
+fi
 
 # If known_hosts is provided, STRICT_HOST_KEY_CHECKING=yes
 # Default CheckHostIP=yes unless SSH_STRICT_HOST_IP_CHECK=false


### PR DESCRIPTION
* Purpose
We need to use an old rancher, that do not support secrets deploy with CLI, we want to use environment variable instead
* Before
ssh key was only available with secret or volume
* Before
ssh key can be define with a secret, volume or env variable
