### PR TITLE
Add SSH_OPTIONS pararameter for tunnels (issue #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,16 @@ Sets the threshold of alive messages after which the connection is terminated an
 
 Additional details are available from [`ssh_config(5)`](https://linux.die.net/man/5/ssh_config)
 
+#### SSH_OPTIONS 
+
+Sets additional parameters to `ssh` connection. Supports more than one parameter. 
+
+Examples:
+ - SSH_OPTIONS="-o StreamLocalBindUnlink=yes" for recreate socket if it exists
+ - SSH_OPTIONS="-o StreamLocalBindUnlink=yes -o UseRoaming=no" for multiple parameters
+
+Additional details are available from [`ssh_config(5)`](https://linux.die.net/man/5/ssh_config)
+
 #### Additional Environment variables
 
 - [`autossh(1)`](https://linux.die.net/man/1/autossh)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -79,6 +79,7 @@ services:
       - SSH_TARGET_HOST=203.0.113.100
       - SSH_TARGET_PORT=22
       - SSH_TUNNEL_PORT=11111
+      - SSH_OPTIONS="-o StreamLocalBindUnlink=yes -o UseRoaming=no"
       - SSH_KEY_FILE=/opt/id_rsa
       - SSH_KNOWN_HOSTS_FILE=/dev/null
       - SSH_STRICT_HOST_IP_CHECK=false

--- a/rootfs/entrypoint.sh
+++ b/rootfs/entrypoint.sh
@@ -54,6 +54,7 @@ COMMAND="autossh "\
 "-o ServerAliveInterval=${SSH_SERVER_ALIVE_INTERVAL:-10} "\
 "-o ServerAliveCountMax=${SSH_SERVER_ALIVE_COUNT_MAX:-3} "\
 "-o ExitOnForwardFailure=yes "\
+"${SSH_OPTIONS} "\
 "-t -t "\
 "${SSH_MODE:=-R} ${SSH_BIND_IP}:${SSH_TUNNEL_PORT}:${SSH_TARGET_HOST}:${SSH_TARGET_PORT} "\
 "-p ${SSH_REMOTE_PORT:=22} "\


### PR DESCRIPTION
Issue #37. SSH_OPTIONS option was added. Tests and docs also changed.

`make docker-test` — successfully pass and return 0
```
...
autossh_sut_1 exited with code 0
Aborting on container exit...
Stopping autossh_local_1      ... done
Stopping autossh_target_1     ... done
Stopping autossh_remote_1     ... done
Stopping autossh_bootloader_1 ... done
```