### PR TITLE
Graceful Tunnel Shutdown 

### DIFF
--- a/rootfs/entrypoint.sh
+++ b/rootfs/entrypoint.sh
@@ -54,6 +54,7 @@ COMMAND="autossh "\
 "-o ServerAliveInterval=${SSH_SERVER_ALIVE_INTERVAL:-10} "\
 "-o ServerAliveCountMax=${SSH_SERVER_ALIVE_COUNT_MAX:-3} "\
 "-o ExitOnForwardFailure=yes "\
+"-o StreamLocalBindUnlink=yes "\
 "-t -t "\
 "${SSH_MODE:=-R} ${SSH_BIND_IP}:${SSH_TUNNEL_PORT}:${SSH_TARGET_HOST}:${SSH_TARGET_PORT} "\
 "-p ${SSH_REMOTE_PORT:=22} "\


### PR DESCRIPTION
Adding an option for SSH to cleanup a broken connection endpoint in case of network failure, as discussed in #25